### PR TITLE
Update LooksMenu and Nameplates for version 1.11.191 compatibility

### DIFF
--- a/f4ee/OverlayInterface.cpp
+++ b/f4ee/OverlayInterface.cpp
@@ -132,7 +132,7 @@ bool OverlayInterface::UpdateOverlays(Actor * actor, NiNode * rootNode, NiAVObje
 			{
 				NiCloningProcess cp;
 				memset(&cp, 0, sizeof(NiCloningProcess));
-				cp.m_eCopyType = NiCloningProcess::COPY_EXACT;
+				cp.unk60 = 1; // cp.m_eCopyType = NiCloningProcess::COPY_EXACT;
 
 				BSTriShape * cloned = (BSTriShape*)item.second->CreateClone(&cp);
 

--- a/f4ee/exports.def
+++ b/f4ee/exports.def
@@ -1,4 +1,4 @@
 LIBRARY	"f4ee"
 EXPORTS
-F4SEPlugin_Query
+F4SEPlugin_Preload
 F4SEPlugin_Load

--- a/f4ee/main.cpp
+++ b/f4ee/main.cpp
@@ -396,8 +396,8 @@ using _AttachSkinnedObject = NiAVObject* (*)(BipedAnim* bipedInfo, NiNode* objec
 RelocAddr< _AttachSkinnedObject> AttachSkinnedObject(BipedAnim::AttachSkinnedObject_Address);
 _AttachSkinnedObject AttachSkinnedObject_Original = nullptr;
 
-RelocPtr<UInt32> g_faceGenTextureWidth(0x02F37900); // "FaceCustomization"
-RelocPtr<UInt32> g_faceGenTextureHeight(0x02F37904);
+RelocPtr<UInt32> g_faceGenTextureWidth(0x02F42910); // "FaceCustomization"
+RelocPtr<UInt32> g_faceGenTextureHeight(0x02F42914);
 
 namespace BSGraphics
 {
@@ -479,7 +479,7 @@ __declspec(dllexport) F4SEPluginVersionData F4SEPlugin_Version =
 	"Expired6978",
 	0,	// not version independent
 	0,	// not version independent (extended field)
-	{ RUNTIME_VERSION_1_11_169, 0 },	// compatible with 1.11.169
+	{ RUNTIME_VERSION_1_11_191, 0 },	// compatible with 1.11.191
 	0,	// works with any version of the script extender. you probably do not need to put anything here
 };
 
@@ -503,9 +503,9 @@ bool F4SEPlugin_Preload(const F4SEInterface * f4se)
 		_FATALERROR("loaded in editor, marking as incompatible");
 		return false;
 	}
-	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_11_169)
+	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_11_191)
 	{
-		UInt32 runtimeVersion = RUNTIME_VERSION_1_11_169;
+		UInt32 runtimeVersion = RUNTIME_VERSION_1_11_191;
 		char buf[512];
 		sprintf_s(buf, "LooksMenu Version Error:\nexpected game version %d.%d.%d.%d\nyour game version is %d.%d.%d.%d\nsome features may not work correctly.", 
 			GET_EXE_VERSION_MAJOR(runtimeVersion), 

--- a/f4ee/main.cpp
+++ b/f4ee/main.cpp
@@ -396,8 +396,8 @@ using _AttachSkinnedObject = NiAVObject* (*)(BipedAnim* bipedInfo, NiNode* objec
 RelocAddr< _AttachSkinnedObject> AttachSkinnedObject(BipedAnim::AttachSkinnedObject_Address);
 _AttachSkinnedObject AttachSkinnedObject_Original = nullptr;
 
-RelocPtr<UInt32> g_faceGenTextureWidth(0x02CDC0D0);
-RelocPtr<UInt32> g_faceGenTextureHeight(0x02CDC0D4);
+RelocPtr<UInt32> g_faceGenTextureWidth(0x02F37900); // "FaceCustomization"
+RelocPtr<UInt32> g_faceGenTextureHeight(0x02F37904);
 
 namespace BSGraphics
 {
@@ -479,11 +479,11 @@ __declspec(dllexport) F4SEPluginVersionData F4SEPlugin_Version =
 	"Expired6978",
 	0,	// not version independent
 	0,	// not version independent (extended field)
-	{ RUNTIME_VERSION_1_10_984, 0 },	// compatible with 1.10.984
+	{ RUNTIME_VERSION_1_11_169, 0 },	// compatible with 1.11.169
 	0,	// works with any version of the script extender. you probably do not need to put anything here
 };
 
-bool F4SEPlugin_Query(const F4SEInterface * f4se)
+bool F4SEPlugin_Preload(const F4SEInterface * f4se)
 {
 	SInt32	logLevel = IDebugLog::kLevel_DebugMessage;
 	if (F4EEGetConfigValue("Debug", "iLogLevel", &logLevel))
@@ -503,9 +503,9 @@ bool F4SEPlugin_Query(const F4SEInterface * f4se)
 		_FATALERROR("loaded in editor, marking as incompatible");
 		return false;
 	}
-	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_10_984)
+	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_11_169)
 	{
-		UInt32 runtimeVersion = RUNTIME_VERSION_1_10_984;
+		UInt32 runtimeVersion = RUNTIME_VERSION_1_11_169;
 		char buf[512];
 		sprintf_s(buf, "LooksMenu Version Error:\nexpected game version %d.%d.%d.%d\nyour game version is %d.%d.%d.%d\nsome features may not work correctly.", 
 			GET_EXE_VERSION_MAJOR(runtimeVersion), 
@@ -566,11 +566,6 @@ bool F4SEPlugin_Query(const F4SEInterface * f4se)
 
 __declspec(dllexport) bool F4SEPlugin_Load(const F4SEInterface * f4se)
 {
-	if (!F4SEPlugin_Query(f4se))
-	{
-		return false;
-	}
-
 	F4EEGetConfigValue("Debug", "bExportRace", &g_bExportRace);
 	std::string strExportRace = F4EEGetConfigOption("Debug", "strExportRace");
 	if(!strExportRace.empty())

--- a/hudextension/HUDExtension.cpp
+++ b/hudextension/HUDExtension.cpp
@@ -15,18 +15,18 @@ const char * HUDExtensionMenu::sMenuName = "HUDExtensionMenu";
 
 HUDExtensionMenu::HUDExtensionMenu() : GameMenuBase()
 {
-	flags = kFlag_DoNotPreventGameSave | kFlag_DisableInteractive | kFlag_Unk800000;
+	flags = kFlag_AllowSaving | kFlag_DontHideCursorWhenTopmost | kFlag_CompanionAppAllowed;
 	if (CALL_MEMBER_FN((*g_scaleformManager), LoadMovie)(this, movie, "HUDExtension", "root1", 2))
 	{
 		if (g_hudSettings.applyFilter)
-			flags |= kFlag_ApplyDropDownFilter;
+			flags |= kFlag_CustomRendering;
 		else
 			stage.SetMember("showShadowEffect", &GFxValue(true));
-		CreateBaseShaderTarget(shaderTarget, stage);
+		CreateBaseShaderTarget(filterHolder, stage);
 
-		if (flags & kFlag_ApplyDropDownFilter)
+		if (flags & kFlag_CustomRendering)
 		{
-			subcomponents.Push(shaderTarget);
+			shaderFXObjects.Push(filterHolder);
 		}
 	}
 }
@@ -68,8 +68,8 @@ void HUDExtensionMenu::PopulateNameplateData(GFxValue * args, TESObjectREFR * re
 
 void HUDExtensionMenu::AddNameplate(GFxValue * parent, const std::shared_ptr<HUDNameplate> & object)
 {
-	TESObjectREFR * refr = nullptr;
-	LookupREFRByHandle(&object->m_refrHandle, &refr);
+	NiPointer<TESObjectREFR> refr = nullptr;
+	LookupREFRByHandle(object->m_refrHandle, refr);
 	if(refr)
 	{
 		if(parent->IsDisplayObject())
@@ -84,14 +84,13 @@ void HUDExtensionMenu::AddNameplate(GFxValue * parent, const std::shared_ptr<HUD
 				object->m_nameplate = new BSGFxShaderFXTarget(&nameplate);
 			}
 		}
-		refr->handleRefObject.DecRefHandle();
 	}
 }
 
 void HUDExtensionMenu::UpdateNameplate(double stageWidth, double stageHeight, const std::shared_ptr<HUDNameplate> & object)
 {
-	TESObjectREFR * refr = nullptr;
-	LookupREFRByHandle(&object->m_refrHandle, &refr);
+	NiPointer<TESObjectREFR> refr = nullptr;
+	LookupREFRByHandle(object->m_refrHandle, refr);
 	if(refr)
 	{
 		NiPoint3 markerPos;
@@ -143,7 +142,7 @@ void HUDExtensionMenu::UpdateNameplate(double stageWidth, double stageHeight, co
 
 			if (refr->formType == Actor::kTypeID) // Type check is faster than RTTI cast
 			{
-				Actor * actor = (Actor*)refr;
+				Actor * actor = (Actor*)refr.get();
 				isHostile = CALL_MEMBER_FN((*g_player), IsHostileToActor)(actor);
 
 				if(g_hudSettings.avInvisibility && actor->actorValueOwner.GetValue(g_hudSettings.avInvisibility) > 0.0f) {
@@ -186,18 +185,16 @@ void HUDExtensionMenu::UpdateNameplate(double stageWidth, double stageHeight, co
 					nameplate->SetFilterColor(isHostile);
 				else
 				{
-					FilterColor color; // RRGGBB
+					NiColor color; // RRGGBB
 					color.r = float((clrBar >> 16) & 0xFF) / 255.0f;
 					color.g = float((clrBar >> 8) & 0xFF) / 255.0f;
 					color.b = float(clrBar & 0xFF) / 255.0f;
-					ApplyColorFilter(nameplate, &color, 1.0f);
+					nameplate->EnableColorMultipliers(& color, 1.0f);
 				}
 			}
 
 			nameplate->SetMember("visible", &GFxValue(isVisible)); // Visibility flag doesnt seem to work from DisplayInfo...?
 		}
-
-		refr->handleRefObject.DecRefHandle();
 	}
 }
 
@@ -206,7 +203,7 @@ void HUDExtensionMenu::RegisterFunctions()
 	
 }
 
-void HUDExtensionMenu::DrawNextFrame(float unk0, void * unk1)
+void HUDExtensionMenu::AdvanceMovie(float unk0, void * unk1)
 {
 	if(!stage.IsDisplayObject())
 		return;
@@ -217,6 +214,7 @@ void HUDExtensionMenu::DrawNextFrame(float unk0, void * unk1)
 
 	// Deal with all pending removes first
 	m_lock.Lock();
+
 	for(auto & removals : m_qRemove)
 	{
 		GFxValue success;
@@ -228,10 +226,10 @@ void HUDExtensionMenu::DrawNextFrame(float unk0, void * unk1)
 		{
 			if(removals.second)
 			{
-				BSGFxDisplayObject * target = removals.second->m_nameplate;
-				SInt64 i = subcomponents.GetItemIndex(target);
+				BSGFxShaderFXTarget * target = removals.second->m_nameplate;
+				SInt64 i = shaderFXObjects.GetItemIndex(target);
 				if(i != -1) {
-					subcomponents.Remove(i);
+					shaderFXObjects.Remove(i);
 				}
 			}
 			m_mapPlates.erase(it);
@@ -244,7 +242,7 @@ void HUDExtensionMenu::DrawNextFrame(float unk0, void * unk1)
 		AddNameplate(&stage, adds.second);
 		m_mapPlates.emplace(adds.first, adds.second);
 		if(adds.second) {
-			subcomponents.Push(adds.second->m_nameplate);
+			shaderFXObjects.Push(adds.second->m_nameplate);
 		}
 	}
 	m_qAdd.clear();
@@ -260,7 +258,7 @@ void HUDExtensionMenu::DrawNextFrame(float unk0, void * unk1)
 	m_lock.Release();
 
 	stage.Invoke("SortChildrenByDepth", nullptr, nullptr, 0);
-	__super::DrawNextFrame(unk0, unk1);
+	__super::AdvanceMovie(unk0, unk1);
 }
 
 HUDNameplate::HUDNameplate(UInt32 refrHandle, GFxValue * nameplate) : m_refrHandle(refrHandle), m_nameplate(nullptr)
@@ -280,7 +278,8 @@ bool HUDExtensionMenu::AddNameplate(TESObjectREFR * refr)
 {
 	SimpleLocker locker(&m_lock);
 
-	UInt32 refrHandle = refr->CreateRefHandle();
+	UInt32 refrHandle = *g_invalidRefHandle;
+	CreateHandleByREFR(refrHandle, refr);
 	if(refrHandle == (*g_invalidRefHandle)) {
 		_MESSAGE("Invalid handle on add");
 		return false;
@@ -306,7 +305,8 @@ bool HUDExtensionMenu::RemoveNameplate(TESObjectREFR * refr)
 {
 	SimpleLocker locker(&m_lock);
 
-	UInt32 refrHandle = refr->CreateRefHandle();
+	UInt32 refrHandle = *g_invalidRefHandle;
+	CreateHandleByREFR(refrHandle, refr);
 	if(refrHandle == (*g_invalidRefHandle)) {
 		_MESSAGE("Invalid handle on remove");
 		return false;
@@ -353,10 +353,10 @@ void HUDExtensionMenu::ForceClear()
 	{
 		if(plate.second)
 		{
-			BSGFxDisplayObject * target = plate.second->m_nameplate;
-			SInt64 i = subcomponents.GetItemIndex(target);
+			BSGFxShaderFXTarget * target = plate.second->m_nameplate;
+			SInt64 i = shaderFXObjects.GetItemIndex(target);
 			if(i != -1) {
-				subcomponents.Remove(i);
+				shaderFXObjects.Remove(i);
 			}
 		}
 	}

--- a/hudextension/HUDExtension.cpp
+++ b/hudextension/HUDExtension.cpp
@@ -82,6 +82,11 @@ void HUDExtensionMenu::AddNameplate(GFxValue * parent, const std::shared_ptr<HUD
 			parent->Invoke("AddNameplate", &nameplate, args, 5);
 			if(nameplate.IsDisplayObject()) {
 				object->m_nameplate = new BSGFxShaderFXTarget(&nameplate);
+				object->m_nameplate->backgroundColorType = kHUDColorTypes_MenuNoColorBackground;
+				if (g_hudSettings.barFlags & HUDSettings::kFlag_ShowBackground)
+					object->m_nameplate->shaderFX.enabledStates |= UIShaderColors::kBackgroundQuad;
+				else
+					object->m_nameplate->shaderFX.enabledStates &= ~UIShaderColors::kBackgroundQuad;
 			}
 		}
 	}

--- a/hudextension/HUDExtension.h
+++ b/hudextension/HUDExtension.h
@@ -73,7 +73,8 @@ struct HUDSettings
 		kFlag_HideEnemy		  = (1 << 3),
 		kFlag_HideUserDefined = (1 << 4),
 		kFlag_ShowLevel		  = (1 << 5),
-		kFlag_HideName        = (1 << 6)
+		kFlag_HideName        = (1 << 6),
+		kFlag_ShowBackground  = (1 << 7)
 	};
 
 	bool applyFilter;

--- a/hudextension/HUDExtension.h
+++ b/hudextension/HUDExtension.h
@@ -38,7 +38,7 @@ public:
 		CALL_MEMBER_FN((*g_uiMessageManager), SendUIMessage)(BSFixedString(sMenuName), kMessage_Close);
 	}
 
-	virtual void DrawNextFrame(float unk0, void * unk1) override final;
+	virtual void AdvanceMovie(float unk0, void * unk1) override final;
 	virtual void RegisterFunctions() override final;
 
 	void AddNameplate(GFxValue * parent, const std::shared_ptr<HUDNameplate> & object);

--- a/hudextension/exports.def
+++ b/hudextension/exports.def
@@ -1,4 +1,4 @@
 LIBRARY	"hudextension"
 EXPORTS
-F4SEPlugin_Query
+F4SEPlugin_Preload
 F4SEPlugin_Load

--- a/hudextension/hudextension.vcxproj
+++ b/hudextension/hudextension.vcxproj
@@ -123,6 +123,7 @@
     <ClCompile Include="..\f4se\GameExtraData.cpp" />
     <ClCompile Include="..\f4se\GameFormComponents.cpp" />
     <ClCompile Include="..\f4se\GameForms.cpp" />
+    <ClCompile Include="..\f4se\GameHandle.cpp" />
     <ClCompile Include="..\f4se\GameMenus.cpp" />
     <ClCompile Include="..\f4se\GameObjects.cpp" />
     <ClCompile Include="..\f4se\GameReferences.cpp" />
@@ -148,6 +149,7 @@
     <ClInclude Include="..\f4se\GameExtraData.h" />
     <ClInclude Include="..\f4se\GameFormComponents.h" />
     <ClInclude Include="..\f4se\GameForms.h" />
+    <ClInclude Include="..\f4se\GameHandle.h" />
     <ClInclude Include="..\f4se\GameMenus.h" />
     <ClInclude Include="..\f4se\GameObjects.h" />
     <ClInclude Include="..\f4se\GameReferences.h" />

--- a/hudextension/hudextension.vcxproj.filters
+++ b/hudextension/hudextension.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="..\f4se\GameData.cpp">
       <Filter>api</Filter>
     </ClCompile>
+    <ClCompile Include="..\f4se\GameHandle.cpp">
+      <Filter>api</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\f4se\ScaleformAPI.h">
@@ -130,6 +133,9 @@
     </ClInclude>
     <ClInclude Include="HUDExtension.h" />
     <ClInclude Include="..\f4se\GameData.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\f4se\GameHandle.h">
       <Filter>api</Filter>
     </ClInclude>
   </ItemGroup>

--- a/hudextension/main.cpp
+++ b/hudextension/main.cpp
@@ -151,7 +151,7 @@ public:
 			return kEvent_Continue;
 
 		BSFixedString menuName(HUDExtensionMenu::sMenuName);
-		if((*g_ui)->IsMenuOpen(menuName))
+		if((*g_ui)->IsMenuRegistered(menuName) && (*g_ui)->IsMenuOpen(menuName))
 		{
 			HUDExtensionMenu * menu = static_cast<HUDExtensionMenu*>((*g_ui)->GetMenu(menuName));
 			if(menu)
@@ -282,7 +282,7 @@ void F4SEMessageHandler(F4SEMessagingInterface::Message* msg)
 extern "C"
 {
 
-bool F4SEPlugin_Query(const F4SEInterface * f4se, PluginInfo * info)
+bool F4SEPlugin_Preload(const F4SEInterface * f4se)
 {
 	SInt32	logLevel = IDebugLog::kLevel_DebugMessage;
 	if (F4HEGetConfigValue("Debug", "iLogLevel", &logLevel))
@@ -292,11 +292,6 @@ bool F4SEPlugin_Query(const F4SEInterface * f4se, PluginInfo * info)
 
 	g_f4seVersion = f4se->f4seVersion;
 
-	// populate info structure
-	info->infoVersion =	PluginInfo::kInfoVersion;
-	info->name =		"F4HE";
-	info->version =		1;
-
 	// store plugin handle so we can identify ourselves later
 	g_pluginHandle = f4se->GetPluginHandle();
 
@@ -305,9 +300,9 @@ bool F4SEPlugin_Query(const F4SEInterface * f4se, PluginInfo * info)
 		_FATALERROR("loaded in editor, marking as incompatible");
 		return false;
 	}
-	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_10_82)
+	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_11_169)
 	{
-		UInt32 runtimeVersion = RUNTIME_VERSION_1_10_82;
+		UInt32 runtimeVersion = RUNTIME_VERSION_1_11_169;
 		char buf[512];
 		sprintf_s(buf, "HUD Extension Version Error:\nexpected game version %d.%d.%d.%d\nyour game version is %d.%d.%d.%d\nsome features may not work correctly.", 
 			GET_EXE_VERSION_MAJOR(runtimeVersion), 
@@ -357,5 +352,20 @@ bool F4SEPlugin_Load(const F4SEInterface * skse)
 
 	return true;
 }
+
+__declspec(dllexport) F4SEPluginVersionData F4SEPlugin_Version =
+{
+	F4SEPluginVersionData::kVersion,
+
+	1,
+	"Fallout 4 HUD Extension",
+	"Expired6978",
+
+	0,	// not version independent
+	0,	// not version independent (extended field)
+	{ RUNTIME_VERSION_1_11_169, 0 },	// compatible with 1.11.169
+
+	0,	// works with any version of the script extender. you probably do not need to put anything here
+};
 
 };

--- a/hudextension/main.cpp
+++ b/hudextension/main.cpp
@@ -300,9 +300,9 @@ bool F4SEPlugin_Preload(const F4SEInterface * f4se)
 		_FATALERROR("loaded in editor, marking as incompatible");
 		return false;
 	}
-	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_11_169)
+	else if(f4se->runtimeVersion != RUNTIME_VERSION_1_11_191)
 	{
-		UInt32 runtimeVersion = RUNTIME_VERSION_1_11_169;
+		UInt32 runtimeVersion = RUNTIME_VERSION_1_11_191;
 		char buf[512];
 		sprintf_s(buf, "HUD Extension Version Error:\nexpected game version %d.%d.%d.%d\nyour game version is %d.%d.%d.%d\nsome features may not work correctly.", 
 			GET_EXE_VERSION_MAJOR(runtimeVersion), 
@@ -363,7 +363,7 @@ __declspec(dllexport) F4SEPluginVersionData F4SEPlugin_Version =
 
 	0,	// not version independent
 	0,	// not version independent (extended field)
-	{ RUNTIME_VERSION_1_11_169, 0 },	// compatible with 1.11.169
+	{ RUNTIME_VERSION_1_11_191, 0 },	// compatible with 1.11.191
 
 	0,	// works with any version of the script extender. you probably do not need to put anything here
 };


### PR DESCRIPTION
I took the liberty of updating the F4EE and F4HE plugins for the Anniversary Update. I took special care to ensure I properly updated all the memory addresses and double-checked all the assembly patches. It seems to work fine on my save file.

You can download the updated mods for version 1.11.191 here:

[LooksMenu](https://www.nexusmods.com/fallout4/mods/12631)

[NamePlates](https://www.nexusmods.com/fallout4/mods/21636)