### PR TITLE
OverlayInterface: Serialize tint color as floats

### DIFF
--- a/f4ee/OverlayInterface.cpp
+++ b/f4ee/OverlayInterface.cpp
@@ -474,13 +474,23 @@ void OverlayInterface::OverlayData::Save(const F4SESerializationInterface * intf
 
 	if((flags & kHasTintColor) == kHasTintColor)
 	{
-		UInt32 a = max(0, min(tintColor.a * 255, 255));
-		UInt32 r = max(0, min(tintColor.r * 255, 255));
-		UInt32 g = max(0, min(tintColor.g * 255, 255));
-		UInt32 b = max(0, min(tintColor.b * 255, 255));
+		if (kVersion >= kVersion3)
+		{
+			Serialization::WriteData<float>(intfc, &tintColor.a);
+			Serialization::WriteData<float>(intfc, &tintColor.r);
+			Serialization::WriteData<float>(intfc, &tintColor.g);
+			Serialization::WriteData<float>(intfc, &tintColor.b);
+		}
+		else
+		{
+			UInt32 a = max(0, min(tintColor.a * 255, 255));
+			UInt32 r = max(0, min(tintColor.r * 255, 255));
+			UInt32 g = max(0, min(tintColor.g * 255, 255));
+			UInt32 b = max(0, min(tintColor.b * 255, 255));
 
-		UInt32 tintARGB = (a << 24) | (r << 16) | (g << 8) | b;
-		Serialization::WriteData<UInt32>(intfc, &tintARGB);
+			UInt32 tintARGB = (a << 24) | (r << 16) | (g << 8) | b;
+			Serialization::WriteData<UInt32>(intfc, &tintARGB);
+		}
 	}
 	if((flags & kHasOffsetUV) == kHasOffsetUV)
 	{
@@ -530,22 +540,51 @@ bool OverlayInterface::OverlayData::Load(const F4SESerializationInterface * intf
 
 	if((flags & kHasTintColor) == kHasTintColor)
 	{
-		UInt32 tintARGB;
-		if (!Serialization::ReadData<UInt32>(intfc, &tintARGB))
+		if (kVersion >= kVersion3)
 		{
-			_ERROR("%s - Error loading overlay tint color", __FUNCTION__);
-			return false;
+			if (!Serialization::ReadData<float>(intfc, &tintColor.a))
+			{
+				_ERROR("%s - Error loading overlay tint color alpha", __FUNCTION__);
+				return false;
+			}
+
+			if (!Serialization::ReadData<float>(intfc, &tintColor.r))
+			{
+				_ERROR("%s - Error loading overlay tint color red", __FUNCTION__);
+				return false;
+			}
+
+			if (!Serialization::ReadData<float>(intfc, &tintColor.g))
+			{
+				_ERROR("%s - Error loading overlay tint color green", __FUNCTION__);
+				return false;
+			}
+
+			if (!Serialization::ReadData<float>(intfc, &tintColor.b))
+			{
+				_ERROR("%s - Error loading overlay tint color blue", __FUNCTION__);
+				return false;
+			}
 		}
+		else
+		{
+			UInt32 tintARGB;
+			if (!Serialization::ReadData<UInt32>(intfc, &tintARGB))
+			{
+				_ERROR("%s - Error loading overlay tint color", __FUNCTION__);
+				return false;
+			}
 
-		float a = (tintARGB >> 24) & 0xFF;
-		float r = (tintARGB >> 16) & 0xFF;
-		float g = (tintARGB >> 8) & 0xFF;
-		float b = tintARGB & 0xFF;
+			float a = (tintARGB >> 24) & 0xFF;
+			float r = (tintARGB >> 16) & 0xFF;
+			float g = (tintARGB >> 8) & 0xFF;
+			float b = tintARGB & 0xFF;
 
-		tintColor.a = max(0, min(a / 255.0f, 1.0f));
-		tintColor.r = max(0, min(r / 255.0f, 1.0f));
-		tintColor.g = max(0, min(g / 255.0f, 1.0f));
-		tintColor.b = max(0, min(b / 255.0f, 1.0f));
+			tintColor.a = max(0, min(a / 255.0f, 1.0f));
+			tintColor.r = max(0, min(r / 255.0f, 1.0f));
+			tintColor.g = max(0, min(g / 255.0f, 1.0f));
+			tintColor.b = max(0, min(b / 255.0f, 1.0f));
+		}
 	}
 
 	if((flags & kHasOffsetUV) == kHasOffsetUV)

--- a/f4ee/OverlayInterface.h
+++ b/f4ee/OverlayInterface.h
@@ -55,7 +55,8 @@ public:
 	{
 		kVersion1 = 1,
 		kVersion2 = 2,	// Version 2 now only saves UInt32 FormID instead of UInt64 Handle
-		kSerializationVersion = kVersion2,
+		kVersion3 = 3,	// Version 3 now saves tint colors as floats instead of integers
+		kSerializationVersion = kVersion3,
 	};
 
 	class OverlayData


### PR DESCRIPTION
The [Immersive Nail Polish mod](https://www.nexusmods.com/fallout4/mods/72535) currently patches F4EE to store tint colors as floats. It seems like a reasonable change to make since colors are stored as floats in-engine.